### PR TITLE
use underscores in slug for 2023.9 compatibility

### DIFF
--- a/homepod-connect-dev/config.yaml
+++ b/homepod-connect-dev/config.yaml
@@ -1,6 +1,6 @@
 name: HomePod Connect Dev
 version: 28.8-ls118
-slug: homepod-connect-dev
+slug: homepod_connect_dev
 description: This addon is used to test new versions of OwnTone
 arch:
   - aarch64

--- a/homepod-connect/config.yaml
+++ b/homepod-connect/config.yaml
@@ -1,6 +1,6 @@
 name: HomePod Connect
 version: 28.8-ls118
-slug: homepod-connect
+slug: homepod_connect
 description: Play Spotify music on your HomePods through Spotify Connect
 arch:
   - aarch64


### PR DESCRIPTION
Home Assistant seems to now only accept “_” as a valid separator in add-on slugs. Thus, the hassio.addon_restart service fails with error “invalid slug” when trying to restart this add-on, “63120367_homepod-connect”, due to the dash.