### PR TITLE
Include and Airplay 1 source and Airplay 1 sink in HomePod Connect

### DIFF
--- a/homepod_connect_dev/DOCS.md
+++ b/homepod_connect_dev/DOCS.md
@@ -11,6 +11,12 @@ You can configure OwnTone through its configuration file. It can be found at `/c
 
 Librespot-java is configurable through its configuration file at `/config/owntone/librespot-java.toml`
 
+The configuration page allows you to enable/disable the Airplay instances, name them, change the tcp/udp port if needed, and choose from two logging levels. The Airplay instances are also configurable through thier configuration files at `/config/owntone/shairport-sync-pipe.conf` and `/config/owntone/shairport-sync-audio.conf`.
+
+Also on the configuration page, the [librespot-java](https://github.com/librespot-org/librespot-java) cache can be enabled/disabled and the Home Assistant audio device can be chosen.
+
+Please note, the Airplay instance that will pipe audio and metadata to Owntone for whole house audio will pause play on librespot-java when a device connects to it to prevent overlapping garbled sound.  When the device disconnects form the Airplay instance, it may take a few seconds for the pipe to clear and librespot-java can provide clear audio.
+
 After adjusting something, please restart the add-on.
 
 

--- a/homepod_connect_dev/README.md
+++ b/homepod_connect_dev/README.md
@@ -1,28 +1,51 @@
-# HomePod Connect
+# HomePod Connect Docker Image
 
-This add-on allows you to stream music directly to your HomePods from Spotify.
+This is the offical Docker image of the Home Assistant add-on [HomePod Connect](https://community.home-assistant.io/t/homepod-connect-spotify-on-homepods-with-spotify-connect/482227). You can also use it by itself on other systems. It works out of the box with zeroconf and can be discovered inside your local network.
 
-You can find more details on the [Home Assistant Community post](https://community.home-assistant.io/t/homepod-connect-spotify-on-homepods-with-spotify-connect/482227) and in the Documentation tab.
+## Difference to linuxserver/daapd
 
-## Features
-- OwnTone & librespot-java inside one Docker image
-- Ready out of the box with zeroconf & Home Assistant integration
-- Control OwnTone through Home Assistant
-- Metadata support (visible in Home Assistant)
-- Fully customizable through the config files in `/config/owntone`
+This repository contains a customized version of [linuxserver/daapd](https://github.com/linuxserver/docker-daapd). In this image librespot is replaced by [librespot-java](https://github.com/librespot-org/librespot-java) and openjdk11-jre is installed. Also a custom [OwnTone](https://github.com/owntone/owntone-server) and [librespot-java](https://github.com/librespot-org/librespot-java) configuration is provided.
 
-## Requirements
-- A Spotify Premium account
-- At least one HomePod
-- Correct set up in the Home app
-  - Home -> Home Settings -> Allow Speaker & TV Access -> Anyone On the same Network
-  - Home -> Home Settings -> Allow Speaker & TV Access -> Require Password: Disabled
-- VSCode addon or any other text editor to edit the configuration
+In addition, [Shairport Sync](https://github.com/mikebrady/shairport-sync)
+is installed and can be optionally enabled on the configuration page to provide either or both these Airplay instances:
 
-## Comfort features
-Additionally to this addon, I recommend to use the Home Assistant OwnTone integration. With that, you can control which HomePod should play music.
+1. An Airplay instance that will pipe audio and metadata to Owntone for whole house audio from any source that can play to an Airplay 1 device. This Airplay instance is hidden from OwnTone so it does not pipe back to OwnTone.
 
-[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=forked_daapd)
+2. An Airplay instance that will play to the audio device of the Home Assistant host.
 
-<!-- Second, there is a blueprint that allows you to automatically play music in a room as soon as someone enters it.
-You can find it in the Home Assistant Community. -->
+The changes can be viewed inside the `Dockerfile`. 
+
+This image is built automatically when a new linuxserver/daapd or Shairport Sync version is released.
+
+## Usage
+
+You can pull the image by using
+```bash
+docker pull alexbabel/owntone:VERSION
+```
+or use GHCR:
+```bash
+docker pull ghcr.io/alexanderbabel/owntone:VERSION
+```
+
+Run the image:
+```bash
+docker run --network=host -v $(pwd)/config:/config/owntone alexbabel/owntone:VERSION
+```
+
+## Access
+You can access the OwnTone instance on the default port (3689).
+
+## Configuration
+All configuration files are stored inside the docker image in `/config/owntone`. There, you can find multple files:
+
+- [`librespot-java.toml`](https://github.com/AlexanderBabel/owntone/blob/main/root/defaults/librespot-java.toml) - Configuration for [librespot-java](https://github.com/librespot-org/librespot-java)
+- [`owntone.conf`](https://github.com/AlexanderBabel/owntone/blob/main/root/defaults/owntone.conf) - Configuration for [OwnTone](https://github.com/owntone/owntone-server)
+- [`shairport-sync-pipe.conf`](https://github.com/AlexanderBabel/owntone/blob/main/root/defaults/shairport-sync-pipe.conf) - Configuration for [Shairport Sync](https://github.com/mikebrady/shairport-sync)
+- [`shairport-sync-audio.conf`](https://github.com/AlexanderBabel/owntone/blob/main/root/defaults/shairport-sync-audio.conf) - Configuration for [Shairport Sync](https://github.com/mikebrady/shairport-sync)
+
+All files are adjusted to work out of the box as a Spotify Connect speaker. The content of these files can be found in this repository.
+
+The configuration page allows you to enable/disable the Airplay instances, name them them, change the tcp/udp port if needed, and choose from two logging levels.
+
+Also on the configuration page, the [librespot-java](https://github.com/librespot-org/librespot-java) cache can be enabled/disabled and the Home Assistant audio device can be chosen.

--- a/homepod_connect_dev/config.yaml
+++ b/homepod_connect_dev/config.yaml
@@ -1,9 +1,8 @@
-name: HomePod Connect Dev
-version: 28.8-ls118
-slug: homepod_connect_dev
-description: This addon is used to test new versions of OwnTone
+name: HomePod Connect iV
+version: iV1_2.3.6
+slug: homepod_connectiv
+description: Play Spotify music on your HomePods through Spotify Connect iV
 arch:
-  - aarch64
   - amd64
 map:
   - config:rw
@@ -14,12 +13,29 @@ host_ipc: false
 hassio_api: false
 auth_api: false
 hassio_role: "default"
-audio: false
+audio: true
 init: false
 startup: application
 boot: auto
-image: alexbabel/owntone
 webui: http://[HOST]:[PORT:3689]
 stage: experimental
 url: https://community.home-assistant.io/t/homepod-connect-spotify-on-homepods-with-spotify-connect/482227
+options:
+  airplay_pipe: false
+  airplay_pipe_name: "HomePod Connect"
+  airplay_pipe_port: "5000"
+  airplay_audio: false
+  airplay_audio_name: "HAOS Audio"
+  airplay_audio_port: "5003"
+  shairport_sync_log_level: "v"
+  librespot_java_cache: false
+schema:
+  airplay_pipe: bool
+  airplay_pipe_name: str
+  airplay_pipe_port: list(5000|5001|5002)
+  airplay_audio: bool
+  airplay_audio_name: str
+  airplay_audio_port: list(5003|5004|5005)
+  shairport_sync_log_level: list(v|vv)
+  librespot_java_cache: bool
 homeassistant: "0.110"

--- a/homepod_connect_dev/translations/en.yaml
+++ b/homepod_connect_dev/translations/en.yaml
@@ -1,0 +1,33 @@
+configuration:
+  airplay_pipe:
+    name: Shairport Sync Airplay pipe
+    description: >-
+      Enable Shairport Sync Airplay as Owntone pipe input.
+  airplay_pipe_name:
+    name: Airplay pipe reciever name
+    description: >-
+      Airplay pipe reciever name visible to clients.
+  airplay_pipe_port:
+    name: Airplay pipe tcp/udp port
+    description: >-
+      Choose a differnt port number if running multiple Airplay instances on this server.
+  airplay_audio:
+    name: Shairport Sync Airplay audio
+    description: >-
+      Enable Shairport Sync Airplay as HAOS Audio input.
+  airplay_audio_name:
+    name: Airplay audio reciever name
+    description: >-
+      Airplay audio reciever name visible to clients.
+  airplay_audio_port:
+    name: Airplay audio tcp/udp port
+    description: >-
+      Choose a differnt port number if running multiple Airplay instances on this server.
+  librespot_java_cache:
+    name: Librespot-java song caching.
+    description: >-
+      The cache can take up a lot of space disk. Enable as needed.
+  shairport_sync_log_level:
+    name: Shairport Sync log level
+    description: >-
+      Minimal or more verbose logging.


### PR DESCRIPTION
 I have been using this setup in Debian for while using librespot java and Owntone with two shairport-sync instances. One instance is an Airplay 1 receiver that pipes audio and metadata to owntone so that any device that can play to Airplay 1 can play to owntone multi-room audio. The second is an Airplay 1 receiver that plays to the Home Assistant pulse-audio device so that should there be an audio device on the Home Assistant server in can play synchronized with the rest of the multi-room receivers from owntone.

I have been putting this setup through the paces for a while and it works flawlessly.  I tied to make it as easy to understand and implement users with a configuration page updates to the readme.  I do hope you will consider this functionality for HomePod Connect as it will make it the best,most flexible and easiest to maintain all in one multiroom audio system around.

The Docker part will be in a separate pull request.

Thanks,
ivolt1