### PR TITLE
Change startup mode to services

### DIFF
--- a/homepod_connect/config.yaml
+++ b/homepod_connect/config.yaml
@@ -16,7 +16,7 @@ auth_api: false
 hassio_role: "default"
 audio: false
 init: false
-startup: application
+startup: services
 boot: auto
 image: alexbabel/owntone
 webui: http://[HOST]:[PORT:3689]

--- a/homepod_connect_dev/config.yaml
+++ b/homepod_connect_dev/config.yaml
@@ -16,7 +16,7 @@ auth_api: false
 hassio_role: "default"
 audio: false
 init: false
-startup: application
+startup: services
 boot: auto
 image: alexbabel/owntone
 webui: http://[HOST]:[PORT:3689]


### PR DESCRIPTION
Not sure if anyone else has encountered this, but I've been having an issue with the Owntone integration controlling the HomePod Connect Owntone instance after a VM reboot. The integration would be able to read the state of entities, but no controls would go through until either a HA reboot or the Owntone integration config was deleted and re-added. 

Looked into it a bit and ended up resolving it by changing the add-on config startup option to "services" from "application", so that the add-on is ready prior to Home Assistant starting. 